### PR TITLE
Add CORAL for aligning C_1 and \hat{C}_2

### DIFF
--- a/example/sl-prediction/Snakefile
+++ b/example/sl-prediction/Snakefile
@@ -17,7 +17,8 @@ NO_LANDMARKS = 'no_landmarks'
 # Load required modules
 from os.path import join
 
-RUN_NAME = '-'.join([DATASET_NAME, SRC_SPECIES, TGT_SPECIES])
+RUN_NAME  = '-'.join([DATASET_NAME, SRC_SPECIES, TGT_SPECIES])
+RUN_NAME += '-coral' if config.get('normalization') == 'coral' else ''
 
 # Directories
 SRC_CODE_DIR  = '../../src'
@@ -31,6 +32,7 @@ HANDL = join(SRC_CODE_DIR, 'handl.py')
 
 EMBEDDING_FORMAT_STR = '%s/{name}-HANDL-embedding.pkl' % (EMBEDDINGS_DIR)
 SRC_EMBEDDING = EMBEDDING_FORMAT_STR.format(name=SRC_SPECIES)
+RAW_SRC_EMBEDDING = '%s/%s-HANDL-embedding-raw.pkl' % (EMBEDDINGS_DIR, SRC_SPECIES)
 TGT_EMBEDDING = EMBEDDING_FORMAT_STR.format(name=TGT_SPECIES)
 
 FEATURE_FORMAT_STR = '%s/{name}-features-{landmarks}.pkl' % FEATURES_DIR
@@ -51,7 +53,6 @@ rule all:
     input:
         expand(PREDICTION_SUMMARY_FMT, hold_out=config.get('hold_outs'), landmarks=[WITH_LANDMARKS, NO_LANDMARKS]),
         expand(PREDICTION_DATA_FMT, hold_out=config.get('hold_outs'), landmarks=[WITH_LANDMARKS, NO_LANDMARKS])
-        
 
 # Train and predict
 rule train_and_predict:
@@ -65,10 +66,10 @@ rule train_and_predict:
         n_jobs=config.get('n_jobs', 1),
         hold_out=lambda wildcards: wildcards.get('hold_out'),
         classifier=config.get('classifier', 'svm'),
-        n_trees='-nt ' + config.get('n_trees', 100) if 'n_trees' in config else '',
+        n_trees='-nt ' + config.get('n_trees') if 'n_trees' in config else '',
         max_depth='-md ' + config.get('max_depth') if 'max_depth' in config else '',
-        svm_C='-sc ' + config.get('svm_C', 1.0) if 'svm_C' in config else '',
-        svm_tol='-st ' + config.get('svm_tol', 1e-3) if 'svm_tol' in config else ''
+        svm_C='-sc ' + config.get('svm_C') if 'svm_C' in config else '',
+        svm_tol='-st ' + config.get('svm_tol') if 'svm_tol' in config else ''
     threads: config.get('n_jobs', 1)
     output:
         summary=PREDICTION_SUMMARY_FMT,
@@ -100,6 +101,19 @@ rule featurize:
         'python featurize_sls.py -ef {input.embedding} -gif {input.gis} '\
         '-o {output} {params.sinatra_featurize} {params.remove_landmarks}'
 
+# Run normalization (if necessary)
+rule normalize:
+    input:
+        src_embedding=RAW_SRC_EMBEDDING,
+        tgt_embedding=TGT_EMBEDDING
+    params:
+        norm=config.get('normalization', 'none')
+    output:
+        SRC_EMBEDDING
+    shell:
+        'python normalize_embedding.py -sf {input.src_embedding} '\
+        '-tf {input.tgt_embedding} -o {output} -n {params.norm}'
+        
 # Construct embeddings
 rule embed:
     input:
@@ -107,7 +121,7 @@ rule embed:
         tgt_ppi=config.get(TGT).get('ppi'),
         homologs = config.get(SRC).get('homologs').get(TGT)
     output:
-        src_embedding=SRC_EMBEDDING,
+        src_embedding=RAW_SRC_EMBEDDING,
         tgt_embedding=TGT_EMBEDDING,
         sim_scores=SIM_SCORES,
         landmarks=LANDMARKS,

--- a/example/sl-prediction/Snakefile
+++ b/example/sl-prediction/Snakefile
@@ -18,7 +18,7 @@ NO_LANDMARKS = 'no_landmarks'
 from os.path import join
 
 RUN_NAME  = '-'.join([DATASET_NAME, SRC_SPECIES, TGT_SPECIES])
-RUN_NAME += '-coral' if config.get('normalization') == 'coral' else ''
+RUN_NAME += '-' + config.get('normalization') if config.get('normalization') != 'none' else ''
 
 # Directories
 SRC_CODE_DIR  = '../../src'
@@ -31,8 +31,9 @@ LOG_DIR = join(OUTPUT_DIR, 'log')
 HANDL = join(SRC_CODE_DIR, 'handl.py')
 
 EMBEDDING_FORMAT_STR = '%s/{name}-HANDL-embedding.pkl' % (EMBEDDINGS_DIR)
-SRC_EMBEDDING = EMBEDDING_FORMAT_STR.format(name=SRC_SPECIES)
 RAW_SRC_EMBEDDING = '%s/%s-HANDL-embedding-raw.pkl' % (EMBEDDINGS_DIR, SRC_SPECIES)
+SRC_EMBEDDING = EMBEDDING_FORMAT_STR.format(name=SRC_SPECIES)
+RAW_TGT_EMBEDDING = '%s/%s-HANDL-embedding-raw.pkl' % (EMBEDDINGS_DIR, TGT_SPECIES)
 TGT_EMBEDDING = EMBEDDING_FORMAT_STR.format(name=TGT_SPECIES)
 
 FEATURE_FORMAT_STR = '%s/{name}-features-{landmarks}.pkl' % FEATURES_DIR
@@ -104,15 +105,16 @@ rule featurize:
 # Run normalization (if necessary)
 rule normalize:
     input:
-        src_embedding=RAW_SRC_EMBEDDING,
-        tgt_embedding=TGT_EMBEDDING
+        src=RAW_SRC_EMBEDDING,
+        tgt=RAW_TGT_EMBEDDING
     params:
         norm=config.get('normalization', 'none')
     output:
-        SRC_EMBEDDING
+        src=SRC_EMBEDDING,
+        tgt=TGT_EMBEDDING
     shell:
-        'python normalize_embedding.py -sf {input.src_embedding} '\
-        '-tf {input.tgt_embedding} -o {output} -n {params.norm}'
+        'python normalize_embedding.py -sf {input.src} -tf {input.tgt} '\
+        '-osf {output.src} -otf {output.tgt} -n {params.norm}'
         
 # Construct embeddings
 rule embed:
@@ -122,7 +124,7 @@ rule embed:
         homologs = config.get(SRC).get('homologs').get(TGT)
     output:
         src_embedding=RAW_SRC_EMBEDDING,
-        tgt_embedding=TGT_EMBEDDING,
+        tgt_embedding=RAW_TGT_EMBEDDING,
         sim_scores=SIM_SCORES,
         landmarks=LANDMARKS,
         runtimes=RUNTIMES_FILE

--- a/example/sl-prediction/configs/toy.json
+++ b/example/sl-prediction/configs/toy.json
@@ -16,6 +16,7 @@
 	}
     },
     "n_landmarks": 20,
+    "normalization": "coral",
     "dataset_name": "toy",
     "hold_outs": ["genes", "pairs"]
 }

--- a/example/sl-prediction/configs/toy.json
+++ b/example/sl-prediction/configs/toy.json
@@ -16,7 +16,7 @@
 	}
     },
     "n_landmarks": 20,
-    "normalization": "coral",
+    "normalization": "coral-src",
     "dataset_name": "toy",
     "hold_outs": ["genes", "pairs"]
 }

--- a/example/sl-prediction/constants.py
+++ b/example/sl-prediction/constants.py
@@ -15,5 +15,7 @@ GENES = 'genes'
 GENE_PAIRS = 'pairs'
 
 # Normalization choices
-CORAL_NORM = 'coral'
+CORAL_SRC_NORM = 'coral-src' # align source "into" target
+CORAL_TGT_NORM = 'coral-tgt' # align target non-landmarks into target landmarks
 NONE_NORM  = 'none'
+NORM_MODES = [ CORAL_SRC_NORM, CORAL_TGT_NORM, NONE_NORM ]

--- a/example/sl-prediction/constants.py
+++ b/example/sl-prediction/constants.py
@@ -13,3 +13,7 @@ FEATURE_FUNCTIONS = { ADD_FEATURES, MEAN_FEATURES }
 # Cross-validation choices
 GENES = 'genes'
 GENE_PAIRS = 'pairs'
+
+# Normalization choices
+CORAL_NORM = 'coral'
+NONE_NORM  = 'none'

--- a/example/sl-prediction/normalize_embedding.py
+++ b/example/sl-prediction/normalize_embedding.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+
+# Load required modules
+import sys, os, logging, numpy as np
+this_dir = os.path.dirname(__file__)
+sys.path.append(os.path.join(this_dir, '../../src'))
+
+# CORAL algorithm (Sun, Feng, & Saenko, arXiv:1612.01939v1)
+def coral(D_S, D_T, source_to_target=True, lamb=0.00001):
+    """
+    Arguments:
+    - D_S: Source data (numpy.array)
+    - D_T: Target data (numpy.array)
+    - source_to_target: Transform source into target space (bool)
+    Returns:
+    - D_S^*: Adjusted source data
+    """
+    # Set up
+    from sklearn.preprocessing import scale
+    from scipy.linalg import sqrtm
+    from numpy.linalg import pinv, inv
+    C_S = np.cov(D_S.T) + lamb*np.eye(D_S.shape[1])
+    C_T = np.cov(D_T.T) + lamb*np.eye(D_T.shape[1])
+    C_S_centered = scale(D_S, with_std = False)
+    C_T_centered = scale(D_T, with_std = False)
+    
+    # Perform CORAL (Algorithm 1)
+    if source_to_target:
+        # this is the recommended approach in the coral paper
+        C_S_sqrt = np.real_if_close(sqrtm(C_S))
+        D_S = C_S_centered @ pinv(C_S_sqrt)
+        return D_S @ np.real_if_close(sqrtm(C_T))
+    else:
+        # contrary to the coral paper we are 'fitting' the target distribution
+        # into the source's distributional shape
+        C_T_sqrt = np.real_if_close(sqrtm(C_T))
+        D_T = C_T_centered @ inv(C_T_sqrt)
+        return D_T @ np.real_if_close(sp.linalg.sqrtm(C_S))
+
+if __name__ == '__main__':
+    # Parse command line arguments
+    import argparse
+    from constants import *
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-sf', '--source_embedding_file', type=str, required=True)
+    parser.add_argument('-tf', '--target_embedding_file', type=str, required=True)
+    parser.add_argument('-o', '--output_file', type=str, required=True)
+    parser.add_argument('-n', '--normalization', type=str, required=True,
+                        choices=[CORAL_NORM, NONE_NORM])
+    parser.add_argument('-v', '--verbosity', type=int, default=logging.INFO, required=False)
+    args = parser.parse_args(sys.argv[1:])
+
+    from i_o import get_logger
+    logger = get_logger(args.verbosity)
+
+    # Load the embeddings
+    from sklearn.externals import joblib
+    logger.info('[Loading embeddings]')
+    obj_A = joblib.load(args.source_embedding_file)
+    X_A = obj_A.get('X')
+    nodes_A = obj_A.get('nodes')
+    landmarks_A = obj_A.get('landmarks')
+    weight_A = obj_A.get('weight')
+    logger.info('- Source embedding: %s nodes' % len(nodes_A))
+
+    obj_B = joblib.load(args.target_embedding_file)
+    X_B = obj_B.get('X')
+    nodes_B = obj_B.get('nodes')
+    logger.info('- Target embedding: %s nodes' % len(nodes_A))
+
+    assert( X_A.shape[1] == X_B.shape[1] )
+
+    # Apply normalization
+    if args.normalization == CORAL_NORM:
+        logger.info('[Aligning feature spaces with CORAL]')
+        X_A = coral(X_A, X_B)
+    elif args.normalization == NONE_NORM:
+        logger.info('[Peforming no normalization]')
+    else:
+        raise NotImplementedError('Normalization mode "%s" not implemented.' % args.normalization)
+
+    # Output aligned source embedding to file
+    from util import save_embeddings
+    save_embeddings(X_A, nodes_A, landmarks_A, args.output_file, weight_A)
+    

--- a/example/sl-prediction/normalize_embedding.py
+++ b/example/sl-prediction/normalize_embedding.py
@@ -6,14 +6,15 @@ this_dir = os.path.dirname(__file__)
 sys.path.append(os.path.join(this_dir, '../../src'))
 
 # CORAL algorithm (Sun, Feng, & Saenko, arXiv:1612.01939v1)
-def coral(D_S, D_T, source_to_target=True, lamb=0.00001):
+def coral(D_S, D_T, lamb=0.00001):
     """
     Arguments:
     - D_S: Source data (numpy.array)
     - D_T: Target data (numpy.array)
-    - source_to_target: Transform source into target space (bool)
+    - lamb: Regularization parameter (float)
     Returns:
-    - D_S^*: Adjusted source data
+    - D_S^*: Adjusted, centered source data
+    - D_T: Centered target data
     """
     # Set up
     from sklearn.preprocessing import scale
@@ -21,21 +22,18 @@ def coral(D_S, D_T, source_to_target=True, lamb=0.00001):
     from numpy.linalg import pinv, inv
     C_S = np.cov(D_S.T) + lamb*np.eye(D_S.shape[1])
     C_T = np.cov(D_T.T) + lamb*np.eye(D_T.shape[1])
-    C_S_centered = scale(D_S, with_std = False)
-    C_T_centered = scale(D_T, with_std = False)
+    D_S_centered = scale(D_S, with_std = False)
+    D_T_centered = scale(D_T, with_std = False)
     
     # Perform CORAL (Algorithm 1)
-    if source_to_target:
-        # this is the recommended approach in the coral paper
-        C_S_sqrt = np.real_if_close(sqrtm(C_S))
-        D_S = C_S_centered @ pinv(C_S_sqrt)
-        return D_S @ np.real_if_close(sqrtm(C_T))
-    else:
-        # contrary to the coral paper we are 'fitting' the target distribution
-        # into the source's distributional shape
-        C_T_sqrt = np.real_if_close(sqrtm(C_T))
-        D_T = C_T_centered @ inv(C_T_sqrt)
-        return D_T @ np.real_if_close(sp.linalg.sqrtm(C_S))
+    C_S_sqrt = np.real_if_close(sqrtm(C_S))
+    D_S = D_S_centered @ pinv(C_S_sqrt)
+    D_S_star = D_S @ np.real_if_close(sqrtm(C_T))
+    
+    # Then center and return
+    D_S_star_centered = scale(D_S_star, with_std=False)
+    
+    return D_S_star_centered, D_T_centered
 
 if __name__ == '__main__':
     # Parse command line arguments
@@ -44,9 +42,10 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('-sf', '--source_embedding_file', type=str, required=True)
     parser.add_argument('-tf', '--target_embedding_file', type=str, required=True)
-    parser.add_argument('-o', '--output_file', type=str, required=True)
+    parser.add_argument('-osf', '--output_source_file', type=str, required=True)
+    parser.add_argument('-otf', '--output_target_file', type=str, required=True)
     parser.add_argument('-n', '--normalization', type=str, required=True,
-                        choices=[CORAL_NORM, NONE_NORM])
+                        choices=NORM_MODES)
     parser.add_argument('-v', '--verbosity', type=int, default=logging.INFO, required=False)
     args = parser.parse_args(sys.argv[1:])
 
@@ -66,14 +65,38 @@ if __name__ == '__main__':
     obj_B = joblib.load(args.target_embedding_file)
     X_B = obj_B.get('X')
     nodes_B = obj_B.get('nodes')
+    landmarks_B = obj_B.get('landmarks')
+    weight_B = obj_B.get('weight')
     logger.info('- Target embedding: %s nodes' % len(nodes_A))
 
     assert( X_A.shape[1] == X_B.shape[1] )
 
-    # Apply normalization
-    if args.normalization == CORAL_NORM:
-        logger.info('[Aligning feature spaces with CORAL]')
-        X_A = coral(X_A, X_B)
+    # Center the source/target, and color source with target covariance
+    if args.normalization == CORAL_SRC_NORM:
+        logger.info('[Aligning feature spaces with CORAL: source into target]')
+        X_A, X_B = coral(X_A, X_B)
+
+    # Center source/target, and color target non-landmarks with target landmarks covariance
+    elif args.normalization == CORAL_TGT_NORM:
+        logger.info('[Aligning feature spaces with CORAL: target non-landmarks into target landmarks]')
+
+        # Extract the landmark/non-landmark indices
+        node_to_index_B = dict(zip(nodes_B, range(len(nodes_B))))
+        B_landmark_indices = [ node_to_index_B[n] for n in landmarks_B ]
+        B_non_landmark_indices = [ node_to_index_B[n] for n in set(nodes_B)-set(landmarks_B) ]
+        
+        X_B_NL = X_B[B_non_landmark_indices]
+        X_B_L = X_B[B_landmark_indices]
+        
+        # Use CORAL to align the non-landmarks to the landmarks, and
+        # then reconstruct the full target space
+        from sklearn.preprocessing import scale
+        X_B_NL, X_B_L = coral(X_B_NL, X_B_L)
+        X_B[B_landmark_indices] = X_B_L
+        X_B[B_non_landmark_indices] = X_B_NL
+        X_A = scale(X_A, with_std=False) # center source so it is comparable to the aligned target
+
+    # No normalization
     elif args.normalization == NONE_NORM:
         logger.info('[Peforming no normalization]')
     else:
@@ -81,5 +104,6 @@ if __name__ == '__main__':
 
     # Output aligned source embedding to file
     from util import save_embeddings
-    save_embeddings(X_A, nodes_A, landmarks_A, args.output_file, weight_A)
+    save_embeddings(X_A, nodes_A, landmarks_A, args.output_source_file, weight_A)
+    save_embeddings(X_B, nodes_B, landmarks_B, args.output_target_file, weight_B)
     


### PR DESCRIPTION
### Contributions

My contributions were to `example/sl-prediction`:

1. I added model selection (using [`GridSearchCV`](http://scikit-learn.org/stable/modules/generated/sklearn.model_selection.GridSearchCV.html)) to `train_and_predict.py`. We now automatically select `C` for the linear SVM and `n_estimators` (number of trees) for the random forest. Note that by default we do the grid search, so runtimes will be slower.
2. I added a `normalize_embeddings` step (and script) that occurs after HANDL and before featurization/training/prediction. There are currently two supported normalizations: `"none"` and `"coral"`.

### Testing

You can test using the toy data, which is currently set up to use CORAL normalization:

    snakemake --configfile=configs/toy.json