### PR TITLE
Homolog mapping SL prediction baseline

### DIFF
--- a/example/homolog_baseline/README.md
+++ b/example/homolog_baseline/README.md
@@ -1,0 +1,21 @@
+# SL prediction baseline with homologs
+
+In this baseline, we say that for a pair of genes (a,b) in a source species, and a pair of genes (u,v) in a target species, that (u,v) is SL iff (a,b) is SL and (a,u) and (b,v) are homologs.
+
+### Notes:
+- Inconclusive GIs are excluded
+- For BioGrid, non SLs are sampled from cartesian product of nodes obtained from PPI networks
+- `-s` option for `homolog_mapping_table.py` triggers the option to sample non SLs
+
+### Usage:
+Run 'Snake --configfile configs/{collins-roguev.yml | biogrid.v3.4.157}' to obtain results for Collins/Roguev or BioGrid v3.4.157.
+
+### Results:
+
+| Source Species       | Target Species       | Precision | Recall   | FPR      | F1       | 
+|----------------------|----------------------|-----------|----------|----------|----------| 
+| Collins (Sc)         | Roguev (Sp)          | 0.269231  | 0.002493 | 0.000384 | 0.004940 | 
+| Roguev (Sp)          | Collins (Sc)         | 0.291667  | 0.001934 | 0.000271 | 0.003842 | 
+| Biogrid 3.4.157 (Sc) | Biogrid 3.4.157 (Sp) | 1.000000  | 0.005203 | 0.000000 | 0.010352 | 
+| Biogrid 3.4.157 (Sp) | Biogrid 3.4.157 (Sc) | 1.000000  | 0.000603 | 0.000000 | 0.001204 | 
+

--- a/example/homolog_baseline/Snakefile
+++ b/example/homolog_baseline/Snakefile
@@ -1,0 +1,37 @@
+# Script
+
+from os.path import join
+HOMOLOG_MAPPING = 'homolog_mapping_table.py'
+
+OUTPUT_DIR = 'output'
+
+rule all:
+    input:
+        A_gis= config['A']['gi'],
+        A_ppis= config['A']['ppi'],
+        B_gis= config['B']['gi'],
+        B_ppis= config['B']['ppi'],
+        homs= config['homologs']
+    params:
+        A_name= config['A']['name'],
+        B_name= config['B']['name'],
+        A_data_name= config['A']['data-name'],
+        B_data_name= config['B']['data-name'],
+        sample_negs = '-s' if config.get('sample-negs') else ''
+    output:
+        join(OUTPUT_DIR, '{}-homolog-mapping-results-table.tsv'.format(config['run-name']))
+    shell:
+        '''
+        python {HOMOLOG_MAPPING}\
+            -saf {input.A_gis}\
+            -sbf {input.B_gis}\
+            -sap {input.A_ppis}\
+            -sbp {input.B_ppis}\
+            -san {params.A_data_name}\
+            -sbn {params.B_data_name}\
+            -sn  {params.A_name} {params.B_name}\
+            -hmf {input.homs}\
+            -of  {output}\
+            {params.sample_negs}
+        '''
+        

--- a/example/homolog_baseline/configs/biogrid.v3.4.157.yml
+++ b/example/homolog_baseline/configs/biogrid.v3.4.157.yml
@@ -1,0 +1,13 @@
+run-name: biogrid.v3.4.157
+A:
+  data-name: biogrid.v3.4.157
+  name: sc
+  gi: ../../data/gi/biogrid/sc/sc-biogrid.v3.4.157-sls-std.tsv
+  ppi: ../../data/ppi/biogrid/sc/sc-biogrid.v3.4.157-ppi-std.tsv
+B:
+  data-name: biogrid.v3.4.157
+  name: sp
+  gi: ../../data/gi/biogrid/sp/sp-biogrid.v3.4.157-sls-std.tsv
+  ppi: ../../data/ppi/biogrid/sp/sp-biogrid.v3.4.157-ppi-std.tsv
+homologs: ../../data/homologs/sc-sp/sc-sp-homologs.txt
+sample-negs: True

--- a/example/homolog_baseline/configs/collins-roguev.yml
+++ b/example/homolog_baseline/configs/collins-roguev.yml
@@ -1,0 +1,13 @@
+run-name: collins-roguev
+A:
+  data-name: collins
+  name: sc
+  gi: ../../data/gi/collins/sc/collins-sc-emap-gis-std.tsv
+  ppi: ../../data/ppi/biogrid/sc/sc-biogrid.v3.4.157-ppi-std.tsv
+B:
+  data-name: roguev
+  name: sp
+  gi: ../../data/gi/roguev/sp/roguev-sp-emap-gis-std.tsv
+  ppi: ../../data/ppi/biogrid/sp/sp-biogrid.v3.4.157-ppi-std.tsv
+homologs: ../../data/homologs/sc-sp/sc-sp-homologs.txt
+sample-negs: False

--- a/example/homolog_baseline/homolog_mapping_predictor.py
+++ b/example/homolog_baseline/homolog_mapping_predictor.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python
+
+################################################################################
+# SETUP
+################################################################################
+# Load required modules
+import sys, os, argparse, pandas as pd
+from collections import defaultdict
+from itertools import product
+from sklearn.metrics import precision_score, recall_score
+
+# Load our modules
+sys.path.append('../../src')
+from i_o import get_logger
+import random
+import networkx as nx
+from util import simple_two_core
+
+################################################################################
+# I/O AND PREDICTION
+################################################################################
+# Load the synthetic lethals
+def load_genetic_interactions_table(gi_table_file, ppi_file,  sample_negs=False):
+    logger = get_logger()
+    GI = pd.read_csv(gi_table_file, sep='\t')
+
+    # Explicitly filter out inconclusives...
+    GI = GI[(GI['Category'] == 'SL') | (GI['Category'] == 'Non-SL')]
+    SL = GI.loc[GI['Category'] == 'SL']
+    pairs  = set( frozenset([u, v]) for u, v in zip(SL['Gene A'], SL['Gene B']))
+
+    # If sample negatives...
+    if sample_negs:
+        assert(len(GI) == len(SL))
+
+        nodes = set(simple_two_core(nx.read_edgelist(ppi_file)).nodes())
+        non_sl_pairs = set()
+        non_gi_data = []
+        while len(non_sl_pairs) != len(pairs):
+            p = frozenset(random.sample(nodes, 2))
+            if p not in pairs and p not in non_sl_pairs:
+                _p = tuple(p)
+                non_sl_pairs.add( p )
+                non_gi_data.append({'Category':'Non-SL', 'Score':1, 'Gene A': _p[0], 'Gene B': _p[1]})
+
+        logger.info('\tAdding %s non-SL pairs for %s total interactions' % (len(non_sl_pairs), len(pairs)))
+        pairs = pairs | set(non_sl_pairs)
+        GI = pd.concat([GI, pd.DataFrame(non_gi_data)])
+        SL = GI.loc[GI['Category'] == 'SL']
+
+    return GI, SL, pairs
+
+# Load a homolog mapping
+def load_homolog_mapping_file(homolog_mapping_file):
+    with open(homolog_mapping_file, 'r') as IN:
+        homologs = set( frozenset(l.rstrip('\n').split()) for l in IN )
+        geneAToHomologs = defaultdict(set)
+        geneBToHomologs = defaultdict(set)
+        for a_gene, b_gene in homologs:
+            geneAToHomologs[a_gene].add( b_gene )
+
+            geneBToHomologs[b_gene].add( a_gene )
+
+    return geneAToHomologs, geneBToHomologs
+
+def predict_sl_from_homolog_mapping(A_data, B_data, geneBToHomologs, verbose=1):
+    A_GI, A_SL, A = A_data
+    B_GI, B_SL, B = B_data
+
+    # Make the predictions. We predict an SL between (u, v) in species B iff
+    # (a) u and v have homologs (u', v') in species A; and, (b) (u', v') have an
+    # SL.
+    def hasSL(SLs, xs, ys):
+        return any( frozenset([x, y]) in SLs for x, y in product(xs, ys) )
+
+    B_true = [ int(c == 'SL') for c in B_GI['Category'] ]
+    B_edges = [ (r['Gene A'], r['Gene B']) for i, r in B_GI.iterrows() ]
+    B_pred = [ int(hasSL(A, geneBToHomologs[u], geneBToHomologs[v]))
+               for u, v in B_edges ]
+
+    return B_edges, B_true, B_pred
+
+# Compute false positive rate for binary class predictions
+def compute_fpr(true, pred):
+    n_neg = len(true)-sum(true)
+    return sum( 1. for x, y in zip(true, pred) if x == 0 and y == 1)/n_neg
+
+################################################################################
+# MAIN
+################################################################################
+# Parse command-line arguments
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-sla', '--species_A_table_file', type=str, required=True)
+    parser.add_argument('-slb', '--species_B_table_file', type=str, required=True)
+    parser.add_argument('-hmf', '--homolog_mapping_file', type=str, required=True)
+    parser.add_argument('-of', '--output_file', type=str, required=True)
+    parser.add_argument('-v', '--verbose', type=int, required=False, default=1)
+    return parser.parse_args()
+
+# Run
+def run( args ):
+    # Load the homologs
+    geneAToHomologs, geneBToHomologs = load_homolog_mapping_file(args.homolog_mapping_file)
+    
+    # Load the genetic interactions
+    A_GI, A_SL, A = load_genetic_interactions_table(args.species_A_table_file)
+    B_GI, B_SL, B = load_genetic_interactions_table(args.species_B_table_file)
+
+    logger = get_logger()
+    if args.verbose > 0:
+        logger.info('* Loaded genetic interactions...')
+        logger.info('\t- %s interactions in species A (%s SLs)' % (len(A_GI), len(A)))
+        logger.info('\t- %s interactions in species B (%s SLs)' % (len(B_GI), len(B)))
+
+    # Make the predictions. We predict an SL between (u, v) in species B iff    # Load and predict
+    B_edges, B_true, B_pred = predict_sl_from_homolog_mapping((A_GI, A_SL, A),
+                                                              (B_GI, B_SL, B),
+                                                              geneBToHomologs,
+                                                              args.verbose)
+    
+    # Compute PR and AUC
+    if args.verbose > 0:
+        logger.info('* Evaluating results...') 
+        logger.info('\tPrecision/TPR: %.3f' % precision_score(B_true, B_pred))
+        logger.info('\tRecall: %.3f' % recall_score(B_true, B_pred))
+        logger.info('\tFPR: %.3f' % compute_fpr(B_true, B_pred))
+
+    ################################################################################
+    # OUTPUT
+    ################################################################################
+    # Output predictions
+    valToName = { 1: "SL", 0: "Non-SL" }
+    items = [ {"Gene A": u, "Gene B": v, "Ground truth": valToName[gt], "Predicted": valToName[p]}
+              for (u, v), gt, p in zip(B_edges, B_true, B_pred) ]
+    df = pd.DataFrame(items)
+    df.to_csv(args.output_file, sep='\t', index=False)
+
+if __name__ == '__main__': run(parse_args())

--- a/example/homolog_baseline/homolog_mapping_table.py
+++ b/example/homolog_baseline/homolog_mapping_table.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python
+
+################################################################################
+# SETUP
+################################################################################
+# Load required modules
+import sys, os, argparse, pandas as pd
+from collections import defaultdict
+from itertools import product, combinations
+from sklearn.metrics import precision_score, recall_score, f1_score
+
+# Load our modules
+from homolog_mapping_predictor import predict_sl_from_homolog_mapping as predict
+from homolog_mapping_predictor import load_homolog_mapping_file, load_genetic_interactions_table, compute_fpr
+sys.path.append('../../src')
+from i_o import get_logger
+
+################################################################################
+# MAIN
+################################################################################
+# Parse command-line arguments
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-saf', '--species_A_files', type=str, required=True, nargs='*')
+    parser.add_argument('-san', '--species_A_names', type=str, required=True, nargs='*') 
+    parser.add_argument('-sap', '--species_A_ppis', type=str, required=True, nargs='*') 
+    parser.add_argument('-sbf', '--species_B_files', type=str, required=True, nargs='*')
+    parser.add_argument('-sbn', '--species_B_names', type=str, required=True, nargs='*') 
+    parser.add_argument('-sbp', '--species_B_ppis', type=str, required=True, nargs='*') 
+    parser.add_argument('-sn', '--species_names', type=str, required=True, nargs=2)
+    parser.add_argument('-hmf', '--homolog_mapping_file', type=str, required=True)
+    parser.add_argument('-of', '--output_file', type=str, required=True)
+    parser.add_argument('-v', '--verbose', type=int, required=False, default=1)
+    parser.add_argument('-s', '--sample_negs', action='store_true')
+    return parser.parse_args()
+
+# Run
+def run( args ):
+    # Set up logging
+    logger = get_logger(args.verbose)
+    logger.info('* Loading input files...')
+    
+    # Load the homologs
+    logger.info('\t- Loading homolog mapping...')
+        
+    geneAToHomologs, geneBToHomologs = load_homolog_mapping_file(args.homolog_mapping_file)
+
+    # Load the genetic interactions
+    logger.info('\t- Loading genetic interaction files...')
+
+    if args.sample_negs:
+        logger.info('\t- Sampling Non-SLs...')
+        
+    As, Bs = [], []
+    for species_A_file, species_A_ppi in zip(args.species_A_files, args.species_A_ppis):
+        As.append(load_genetic_interactions_table(species_A_file, species_A_ppi, args.sample_negs))
+    for species_B_file, species_B_ppi in zip(args.species_B_files, args.species_B_ppis):
+        Bs.append(load_genetic_interactions_table(species_B_file, species_B_ppi, args.sample_negs))
+    
+    # Make predictions
+    logger.info('* Making predictions for each pair of datasets...')
+        
+    items = []
+    for (A_name, (A_GI, A_SL, A)), (B_name, (B_GI, B_SL, B)) in product(zip(args.species_A_names, As), zip(args.species_B_names, Bs)):
+        # Simple progress
+        if args.verbose > 0:
+            logger.info('\t- %s vs. %s' % (A_name, B_name))
+            
+        # Predict B from A
+        B_edges, B_true, B_pred = predict((A_GI, A_SL, A),
+                                          (B_GI, B_SL, B),
+                                          geneBToHomologs,
+                                          args.verbose)
+        items.append({
+            "Dataset A (Species)": '%s (%s)' % (A_name, args.species_names[0]),
+            "Dataset B (Species)": '%s (%s)' % (B_name, args.species_names[1]),
+            "Precision (True Positive Rate)": precision_score(B_true, B_pred),
+            "Recall": recall_score(B_true, B_pred),
+            "False Positive Rate": compute_fpr(B_true, B_pred),
+            "F1 Score": f1_score(B_true, B_pred),
+        })
+        
+        # Predict A from B
+        A_edges, A_true, A_pred = predict((B_GI, B_SL, B),
+                                          (A_GI, A_SL, A),
+                                          geneAToHomologs,
+                                          args.verbose)
+        items.append({
+            "Dataset A (Species)": '%s (%s)' % (B_name, args.species_names[1]),
+            "Dataset B (Species)": '%s (%s)' % (A_name, args.species_names[0]),
+            "Precision (True Positive Rate)": precision_score(A_true, A_pred),
+            "Recall": recall_score(A_true, A_pred),
+            "False Positive Rate": compute_fpr(A_true, A_pred),
+            "F1 Score": f1_score(A_true, A_pred),
+        })
+
+    # Output to file
+    logger.info('* Outputting to file...')
+        
+    df = pd.DataFrame(items)[ ['Dataset A (Species)', 'Dataset B (Species)', 'Precision (True Positive Rate)', 'Recall', 'False Positive Rate', 'F1 Score'] ]
+    df.to_csv(args.output_file, index=0, sep='\t')
+
+if __name__ == '__main__': run(parse_args())


### PR DESCRIPTION
### What I implemented:

I adapted code from the old gitlab repo to perform SL prediction with Homologs. In this baseline, we say that for a pair of genes (a,b) in a source species, and a pair of genes (u,v) in a target species, that (u,v) is SL iff (a,b) is SL and (a,u) and (b,v) are homologs.

### Notes:
- Inconclusive GIs are excluded
- For BioGrid, non SLs are sampled from cartesian product of nodes obtained from PPI networks
- `-s` option for `homolog_mapping_table.py` triggers the option to sample non SLs

### Usage:
Run 'Snake --configfile configs/{collins-roguev.yml | biogrid.v3.4.157}' to obtain results for Collins/Roguev or BioGrid v3.4.157.

### Results:

| Source Species       | Target Species       | Precision | Recall   | FPR      | F1       | 
|----------------------|----------------------|-----------|----------|----------|----------| 
| Collins (Sc)         | Roguev (Sp)          | 0.269231  | 0.002493 | 0.000384 | 0.004940 | 
| Roguev (Sp)          | Collins (Sc)         | 0.291667  | 0.001934 | 0.000271 | 0.003842 | 
| Biogrid 3.4.157 (Sc) | Biogrid 3.4.157 (Sp) | 1.000000  | 0.005203 | 0.000000 | 0.010352 | 
| Biogrid 3.4.157 (Sp) | Biogrid 3.4.157 (Sc) | 1.000000  | 0.000603 | 0.000000 | 0.001204 | 
